### PR TITLE
rev c images

### DIFF
--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_d2h_mc_throughput_bar.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_d2h_mc_throughput_bar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8c7665d232244a0d5bee56f7bef6333024ca6f6208adfd99ce7acbf179c129e
+size 268639

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_h2d_mc_throughput_bar.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_h2d_mc_throughput_bar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d045cf6aa087751e14754b811a7d24d500f0e4dede7482d9e91ff06de4bc6b47
+size 260077

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_d2h_latency.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_d2h_latency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb53e20c4235024f8c1e20bac7960bd96068d92711409946ac38569a3e72c559
+size 87591

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_d2h_throughput.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_d2h_throughput.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d985ee31c5ebd4d0a67ea9afc8255e94a8019adf87dec75c5d9fcf826aba0bd
+size 127431

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_d2h_throughput_mean.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_d2h_throughput_mean.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e4222e5c1022d595e93c735fb75eed26143ba40146488a68c91d45843113763
+size 120617

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_d2h_tp_vs_fifo.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_d2h_tp_vs_fifo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:550d672bdf6db40feabae7c93116b6bba342e9d3322888978301cc0d9d1eca72
+size 123914

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_latency.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_latency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4bab19d124bfaffc5ad2df5a3e64d594960ebd03b3bc4ef7c998c86e2502bf2
+size 121460

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_throughput.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_throughput.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c6e86fcf4231dbd4520fb6326373ecfc136497ea42aa70cb6a076cf92eeebcf
+size 82011

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_throughput_mean.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_throughput_mean.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9198d52e8f837e8a65e7c28e49c0fc09a7df32420c7e08014662d6745a6d00dd
+size 130516

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_tp_at_max_fifo.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_tp_at_max_fifo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3cc0208bea93445ba64e3cea4114ef174a06eb9daa5c3fa89cfc6648316b623
+size 151859

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_tp_vs_fifo.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x1_h2d_tp_vs_fifo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90266c3d0e25a066370de769be2d6fc7e83f3a3f025546908ef4d0eeaee67d9f
+size 109310

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_d2h_latency.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_d2h_latency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68c8963efecbd9122cdbcf557106f5dd5c52affb879af22f7974dc1df1dda45a
+size 98733

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_d2h_throughput.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_d2h_throughput.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ac3a29578378203453723d2f9f2f983f553dfd7bfc25d5fccfc0bd75d0de892
+size 140984

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_d2h_throughput_mean.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_d2h_throughput_mean.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa2c16e84aa0cfc640e77baad3302ee43da2a3a4477936170e0dd8a3a44bd10b
+size 139127

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_d2h_tp_vs_fifo.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_d2h_tp_vs_fifo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bf3fdde3ab6e22b145544a632ddc24bdce801f5da9a995ae82b31d59849d847
+size 153396

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_latency.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_latency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4060d28459dbaa2a25681bae4bd3d4c927080f9a1c62f190ff3939ef4fe266b
+size 117500

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_throughput.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_throughput.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:620691e53d2ffd4ef273e678f4e2fba4a5b283c40e9e4c36983dc23e43b564c7
+size 77672

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_throughput_mean.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_throughput_mean.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:817f87d5c33329b0c68af707da821c04e885f306a1b6cbf732af32cfd020271e
+size 127199

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_tp_at_max_fifo.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_tp_at_max_fifo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5d15fbd97907347069c1f39d66f13fddcd5f067603b415f879cbc4636493510
+size 138110

--- a/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_tp_vs_fifo.png
+++ b/media/tt_metal/tech_reports/TT-Distributed/images/revc_x8_h2d_tp_vs_fifo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b77b1b62091d636cec3fee4a3cc2efe1fdf3a8cebfdd6e653a793591e1ce2dc
+size 112703


### PR DESCRIPTION
tt-metal pr:
https://github.com/tenstorrent/tt-metal/pull/43167

updating our hd benchmarks info with rev c!